### PR TITLE
Update .gitignore to remove node_modules disaster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dev
+node_modules


### PR DESCRIPTION
It's almost surely a bad idea to commit node_modules into your package, and force people to download that. Please be nice to the open source community, ok?

Fixes #1 
