### PR TITLE
Fixes a related .npmignore disaster

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 /dev
+node_modules


### PR DESCRIPTION
More than slightly unbelievable how .npmignore does not contain node_modules inside. cf. #2, related to #1. This pull request fixes that.
